### PR TITLE
Update pyproject.toml: bump version to 0.10.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "flit_core.buildapi"
 [project]
 name = "oc4ids-datastore-pipeline"
 description = "OC4IDS Datastore Pipeline"
-version = "0.8.0"
+version = "0.10.0"
 readme = "README.md"
 dependencies = [
   "alembic",


### PR DESCRIPTION
Bumping version to 0.10.0 for new release. 

Note: This also corrects the version which was out of sync (previously 0.8.0 while the latest tag was v0.9.0)