### PR TITLE
pipeline.py: Log raw response snippet on JSON parse failure

### DIFF
--- a/oc4ids_datastore_pipeline/pipeline.py
+++ b/oc4ids_datastore_pipeline/pipeline.py
@@ -149,9 +149,23 @@ def download_json(dataset_id: str, url: str) -> Any:
         r.raise_for_status()
         response_size = len(r.content)
         logger.info(f"Downloaded {url} ({response_size} bytes)")
-        return r.json()
+        try:
+            return r.json()
+        except Exception as parse_err:
+            error_details = (
+                f"JSON DECODE FAILED FOR: {dataset_id}\n"
+                f"Status: {r.status_code}\n"
+                f"Content-Type: {r.headers.get('Content-Type')}\n"
+                f"--- Response snippet ---\n"
+                f"{r.text[:1000]}\n"
+            )
+            logger.error(error_details)
+            raise ProcessDatasetError(error_details) from parse_err
     except Exception as e:
-        raise ProcessDatasetError(f"Download failed: {str(e)}")
+        if not isinstance(e, ProcessDatasetError):
+            raise ProcessDatasetError(f"Download failed: {str(e)}")
+        else:
+            raise e
 
 
 def validate_json(dataset_id: str, json_data: dict[str, Any]) -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "flit_core.buildapi"
 [project]
 name = "oc4ids-datastore-pipeline"
 description = "OC4IDS Datastore Pipeline"
-version = "0.11.0"
+version = "0.12.0"
 readme = "README.md"
 dependencies = [
   "alembic",


### PR DESCRIPTION
Added error handling to capture the status, content-type, and snippet of the raw response body, and add it to `ProcessDatasetError`, when a dataset fails to parse as JSON, based on internal direction from @duncandewhurst 

"add some more error logging to the email notification so we can see exactly what the Costa Rica server is responding with in place of JSON (e.g. a CAPTCHA)."

Also added an if..else to the final except block to not overwrite specific JSON error details with the 'Download failed' message if the custom error has already been raised. 